### PR TITLE
feat: create database connection

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,11 @@
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+# The following `prisma+postgres` URL is similar to the URL produced by running a local Prisma Postgres 
+# server with the `prisma dev` CLI command, when not choosing any non-default ports or settings. The API key, unlike the 
+# one found in a remote Prisma Postgres URL, does not contain any sensitive information.
+
+DATABASE_URL="prisma+postgres://localhost:51213/?api_key=<api-key>"

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -1,5 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 dist
+.env
 
 # dependencies
 /node_modules
@@ -41,3 +42,4 @@ yarn-error.log*
 **/*.log
 package-lock.json
 **/*.bun
+/src/generated/prisma

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -8,6 +8,18 @@ To get started with this template, simply paste this command into your terminal:
 bun create elysia ./elysia-example
 ```
 
+Start Prisma postgres:
+
+```bash
+bunx prisma dev
+```
+
+Start Prisma Studio:
+
+```bash
+bunx prisma studio
+```
+
 ## Development
 
 To start the development server run:
@@ -15,5 +27,3 @@ To start the development server run:
 ```bash
 bun run dev
 ```
-
-Open http://localhost:3000/ with your browser to see the result.

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,0 +1,15 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}


### PR DESCRIPTION
closes #8

- create database connection
- create `DATABASE_URL` variable found in `.env.example` to use
- updated `README.md` with more information about how to use [Prisma studio](https://www.prisma.io/docs/orm/reference/prisma-cli-reference#studio) and [Prisma postgres](https://www.prisma.io/postgres)